### PR TITLE
Handle reconnection to the broker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inorbit/edge-sdk",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "InOrbit Edge SDK",
   "main": "dist/index.js",
   "author": "support@inorbit.ai",

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ class RobotSession {
         payload: `0|${robotApiKey}`,
         qos: 1,
         retain: true
-      },
+      }
     });
     this.mqtt.on('message', this.#onMessage);
     this.mqtt.on('reconnect', this.#onReconnect);

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import { isFunction } from 'lodash';
 import constants from './constants';
 import messages from './inorbit_pb';
 
-const EDGE_SDK_VERSION = '1.5.3';
+const EDGE_SDK_VERSION = '1.5.4';
 const INORBIT_ENDPOINT_DEFAULT = 'https://control.inorbit.ai/cloud_sdk_robot_config';
 // Agent version reported when a robot connection is open using this SDK
 const AGENT_VERSION = `${EDGE_SDK_VERSION}.edgesdk`;

--- a/src/index.js
+++ b/src/index.js
@@ -172,6 +172,7 @@ class RobotSession {
    * Internal method: callback used on every reconnection to the broker.
    */
   #onReconnect = () => {
+    this.logger.info(`Setting robot ${this.robotId} state as online again.`);
     this.publish('state', `1|${this.robotApiKey}|${this.agentVersion}|${this.name}`, { qos: 1, retain: true });
   }
 


### PR DESCRIPTION
Changelog:
- Handle the [`reconnect` event](https://github.com/mqttjs/MQTT.js?tab=readme-ov-file#event-reconnect). Every time the client reconnects to the broker, it publishes a message with the status `1|...`, so inorbit can set the state as ONLINE. This aims to fix the issue with VDA5050 robots: every time the broker was restarted, the last will message was published (`0|...`), but when the client reconnected to the broker, it never published the status `1|...`. As a consequence, the robot was shown as OFFLINE, but it was actually ONLINE.
- Update agent version to `1.5.4`